### PR TITLE
Update yarn version to 1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:8.11.1
 
+RUN yarn global add yarn@1.6.0
+
 # Add our xvfb script
 RUN apt-get update && apt-get -y install libxi-dev libgl1-mesa-dev xvfb
 ADD xvfb /etc/init.d/xvfb


### PR DESCRIPTION
We're in a weird situation where the latest node lts doesn't ship with the latest yarn. Upgrade so folks can get use yarn 1.6.0.