### PR TITLE
Use node 10 for the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12.0
+FROM node:10.12.0
 
 RUN yarn global add yarn@1.10.1
 


### PR DESCRIPTION
This will be released as v2.0.0 and we will run tasks in parallel with the 1.x and 2.x versions of this base image.