### PR TITLE
Install jq into base image for node 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:8.15.1
 RUN yarn global add yarn@1.13.0
 
 # Add our xvfb script
-RUN apt-get update && apt-get -y install libxi-dev libgl1-mesa-dev xvfb
+RUN apt-get update && apt-get -y install jq libxi-dev libgl1-mesa-dev xvfb
 ADD xvfb /etc/init.d/xvfb
 RUN chmod a+x /etc/init.d/xvfb
 ENV DISPLAY :99


### PR DESCRIPTION
This is a useful dependency that we use in a number of places to parse json files.