### PR TITLE
use yarn 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10.16.3
 
-RUN yarn global add yarn@1.19.0
+RUN yarn global add yarn@1.19.1
 
 # Add our xvfb script
 RUN apt-get update && apt-get -y install jq libxi-dev libgl1-mesa-dev xvfb


### PR DESCRIPTION
Yarn has an integrity bug in 1.19.0 — https://github.com/yarnpkg/yarn/issues/7584. Upgrade our base image to use 1.19.1 instead.