### PR TITLE
Change the base-image to 14.15.1-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.0-buster
+FROM node:14.15.1-buster
 
 RUN yarn global add yarn@1.19.1
 


### PR DESCRIPTION
Changes the base web image to 14.15.1-buster. Change has already been done in the Fusion monorepo though I am not sure what else uses this image that potentially needs testing?